### PR TITLE
chore: slack subscription attribute fix

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-03-28T08:40:26Z",
+  "generated_at": "2023-04-10T04:17:40Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -80,7 +80,7 @@
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 895,
+        "line_number": 896,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/examples/test_event_notifications_v1_examples.py
+++ b/examples/test_event_notifications_v1_examples.py
@@ -68,6 +68,7 @@ subscription_id1 = ''
 subscription_id2 = ''
 subscription_id3 = ''
 subscription_id4 = ''
+subscription_id5 = ''
 fcmServerKey = ''
 fcmSenderId = ''
 integration_id = ''
@@ -1034,7 +1035,7 @@ class TestEventNotificationsV1Examples():
         """
         create_subscription request example
         """
-        global subscription_id, subscription_id1, subscription_id2, subscription_id3, subscription_id4
+        global subscription_id, subscription_id1, subscription_id2, subscription_id3, subscription_id4, subscription_id5
         try:
             print('\ncreate_subscription() result:')
             # begin-create_subscription
@@ -1137,6 +1138,27 @@ class TestEventNotificationsV1Examples():
             print(json.dumps(subscription, indent=2))
 
             subscription_id4 = subscription.get('id')
+
+            name = "slack subscription"
+            description = "Subscription for the slack"
+
+            subscription_create_attributes_model = {
+                'attachment_color': '#0000FF',
+            }
+
+            subscription = self.event_notifications_service.create_subscription(
+                instance_id,
+                name,
+                destination_id=destination_id4,
+                topic_id=topic_id,
+                description=description,
+                attributes=subscription_create_attributes_model
+            ).get_result()
+
+            print(json.dumps(subscription, indent=2))
+
+            subscription_id5 = subscription.get('id')
+
         except ApiException as e:
             pytest.fail(str(e))
 
@@ -1289,6 +1311,22 @@ class TestEventNotificationsV1Examples():
 
             subscription_response = update_subscription_response.get_result()
             print(json.dumps(subscription_response, indent=2))
+
+            name = 'Slack update'
+            description = 'Subscription for slack updated'
+            subscription_update_attributes_model = {
+                'attachment_color': '#0000FF',
+            }
+            update_subscription_response = self.event_notifications_service.update_subscription(
+                instance_id,
+                id=subscription_id5,
+                name=name,
+                description=description,
+                attributes=subscription_update_attributes_model,
+            )
+
+            subscription_response = update_subscription_response.get_result()
+            print(json.dumps(subscription_response, indent=2))
             # end-update_subscription
         except ApiException as e:
             pytest.fail(str(e))
@@ -1379,7 +1417,7 @@ class TestEventNotificationsV1Examples():
             # end-delete_subscription
             print('\ndelete_subscription() response status code: ', response.get_status_code())
 
-            for id in [subscription_id1, subscription_id2, subscription_id3, subscription_id4]:
+            for id in [subscription_id1, subscription_id2, subscription_id3, subscription_id4, subscription_id5]:
                 delete_subscription_response = event_notifications_service.delete_subscription(
                     instance_id,
                     id

--- a/ibm_eventnotifications/event_notifications_v1.py
+++ b/ibm_eventnotifications/event_notifications_v1.py
@@ -6942,19 +6942,21 @@ class SubscriptionAttributesSlackAttributesResponse(SubscriptionAttributes):
     """
     The attributes for a Slack notification.
 
-    :attr str attachment_color: Attachment Color for Slack Notification.
+    :attr str attachment_color: (optional) Attachment Color for Slack Notification.
     """
 
     # The set of defined properties for the class
     _properties = frozenset(['attachment_color'])
 
     def __init__(self,
-                 attachment_color: str,
+                 *,
+                 attachment_color: str = None,
                  **kwargs) -> None:
         """
         Initialize a SubscriptionAttributesSlackAttributesResponse object.
 
-        :param str attachment_color: Attachment Color for Slack Notification.
+        :param str attachment_color: (optional) Attachment Color for Slack
+               Notification.
         :param **kwargs: (optional) Any additional properties.
         """
         # pylint: disable=super-init-not-called
@@ -6968,8 +6970,6 @@ class SubscriptionAttributesSlackAttributesResponse(SubscriptionAttributes):
         args = {}
         if 'attachment_color' in _dict:
             args['attachment_color'] = _dict.get('attachment_color')
-        else:
-            raise ValueError('Required property \'attachment_color\' not present in SubscriptionAttributesSlackAttributesResponse JSON')
         args.update({k:v for (k, v) in _dict.items() if k not in cls._properties})
         return cls(**args)
 
@@ -7393,15 +7393,17 @@ class SubscriptionCreateAttributesSlackAttributes(SubscriptionCreateAttributes):
     """
     The attributes for a slack notification.
 
-    :attr str attachment_color: Attachment Color for the slack message.
+    :attr str attachment_color: (optional) Attachment Color for the slack message.
     """
 
     def __init__(self,
-                 attachment_color: str) -> None:
+                 *,
+                 attachment_color: str = None) -> None:
         """
         Initialize a SubscriptionCreateAttributesSlackAttributes object.
 
-        :param str attachment_color: Attachment Color for the slack message.
+        :param str attachment_color: (optional) Attachment Color for the slack
+               message.
         """
         # pylint: disable=super-init-not-called
         self.attachment_color = attachment_color
@@ -7412,8 +7414,6 @@ class SubscriptionCreateAttributesSlackAttributes(SubscriptionCreateAttributes):
         args = {}
         if 'attachment_color' in _dict:
             args['attachment_color'] = _dict.get('attachment_color')
-        else:
-            raise ValueError('Required property \'attachment_color\' not present in SubscriptionCreateAttributesSlackAttributes JSON')
         return cls(**args)
 
     @classmethod
@@ -7773,15 +7773,17 @@ class SubscriptionUpdateAttributesSlackAttributes(SubscriptionUpdateAttributes):
     """
     The attributes for a slack notification.
 
-    :attr str attachment_color: Attachment Color for the slack message.
+    :attr str attachment_color: (optional) Attachment Color for the slack message.
     """
 
     def __init__(self,
-                 attachment_color: str) -> None:
+                 *,
+                 attachment_color: str = None) -> None:
         """
         Initialize a SubscriptionUpdateAttributesSlackAttributes object.
 
-        :param str attachment_color: Attachment Color for the slack message.
+        :param str attachment_color: (optional) Attachment Color for the slack
+               message.
         """
         # pylint: disable=super-init-not-called
         self.attachment_color = attachment_color
@@ -7792,8 +7794,6 @@ class SubscriptionUpdateAttributesSlackAttributes(SubscriptionUpdateAttributes):
         args = {}
         if 'attachment_color' in _dict:
             args['attachment_color'] = _dict.get('attachment_color')
-        else:
-            raise ValueError('Required property \'attachment_color\' not present in SubscriptionUpdateAttributesSlackAttributes JSON')
         return cls(**args)
 
     @classmethod

--- a/test/integration/test_event_notifications_v1.py
+++ b/test/integration/test_event_notifications_v1.py
@@ -1492,12 +1492,17 @@ class TestEventNotificationsV1():
         name = "slack subscription"
         description = "Subscription for the slack"
 
+        subscription_create_attributes_model = {
+            'attachment_color': '#0000FF',
+        }
+
         create_subscription_response = self.event_notifications_service.create_subscription(
             instance_id,
             name,
             destination_id=destination_id4,
             topic_id=topic_id,
-            description=description
+            description=description,
+            attributes=subscription_create_attributes_model
         )
 
         assert create_subscription_response.get_status_code() == 201
@@ -1897,11 +1902,15 @@ class TestEventNotificationsV1():
 
         name = 'Slack update'
         description = 'Subscription for slack updated'
+        subscription_update_attributes_model = {
+            'attachment_color': '#0000FF',
+        }
         update_subscription_response = self.event_notifications_service.update_subscription(
             instance_id,
             id=subscription_id4,
             name=name,
             description=description,
+            attributes=subscription_update_attributes_model,
         )
 
         assert update_subscription_response.get_status_code() == 200


### PR DESCRIPTION
## PR summary
At the time of subscription creation of slack, attribute attachment_color was made as mandatory which is required to be optional.

**Fixes:** https://github.ibm.com/Notification-Hub/planning/issues/8059

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
attribute attachment_color was made as mandatory which is required to be optional for slack subscription.

## What is the new behavior?  
attribute attachment_color is made optional.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->