### PR TITLE
chore: focal as the default build distribution for x86

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: focal
-group: beta
 
 language: python
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-dist: bionic
+dist: focal
+group: beta
 
 language: python
 


### PR DESCRIPTION
## PR summary
updated focal as the default build distribution for x86

**Fixes:** https://github.ibm.com/Notification-Hub/planning/issues/10746

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
was using bionic as default build distribution for x86

## What is the new behavior?  
using focal as the default build distribution for x86

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->