### PR TITLE
chore: making api_key as deprecated for pagerduty destination

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-02-25T18:03:37Z",
+  "generated_at": "2025-04-21T03:21:16Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -104,7 +104,7 @@
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1164,
+        "line_number": 1251,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -112,7 +112,7 @@
         "hashed_secret": "3235b7f8d626cde63611d2e9ec43473f4e844c67",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2048,
+        "line_number": 2266,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -122,7 +122,7 @@
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 593,
+        "line_number": 605,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -130,7 +130,7 @@
         "hashed_secret": "0cc20f91828bed53ddb6294968b7f9abd631a3ba",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1508,
+        "line_number": 1584,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -138,7 +138,7 @@
         "hashed_secret": "3235b7f8d626cde63611d2e9ec43473f4e844c67",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3191,
+        "line_number": 3385,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -148,7 +148,7 @@
         "hashed_secret": "b8473b86d4c2072ca9b08bd28e373e8253e865c4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9881,
+        "line_number": 9933,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/README.md
+++ b/README.md
@@ -1242,6 +1242,16 @@ If you encounter an issue with the project, you are welcome to submit a
 [bug report](https://github.com/IBM/event-notifications-python-admin-sdk/issues).
 Before that, please search for similar issues. It's possible that someone has already reported the problem.
 
+## ⚠️ Deprecation Notice (Attributes)
+
+### Pagerduty Destination Configuration
+
+> The following attribute from interface DestinationConfigOneOfPagerDutyDestinationConfig is **deprecated** and will be removed in a future release:
+
+- `api_key`
+
+This attribute no longer recommended for use and may not be supported in upcoming versions of the SDK. Only `routing_key` is expected to be passed.
+
 ## Open source @ IBM
 
 Find more open source projects on the [IBM Github Page](http://ibm.github.io/)

--- a/ibm_eventnotifications/event_notifications_v1.py
+++ b/ibm_eventnotifications/event_notifications_v1.py
@@ -10433,7 +10433,7 @@ class DestinationConfigOneOfEventStreamsDestinationConfig(DestinationConfigOneOf
     Payload describing a Event Streams destination configuration.
 
     :attr str crn: CRN of the Event Streans instance.
-    :attr str endpoint: End Point of Event Streams.
+    :attr str endpoint: Endpoint of Event Streams.
     :attr str topic: Topic of Event Streams.
     """
 
@@ -10447,7 +10447,7 @@ class DestinationConfigOneOfEventStreamsDestinationConfig(DestinationConfigOneOf
         Initialize a DestinationConfigOneOfEventStreamsDestinationConfig object.
 
         :param str crn: CRN of the Event Streans instance.
-        :param str endpoint: End Point of Event Streams.
+        :param str endpoint: Endpoint of Event Streams.
         :param str topic: Topic of Event Streams.
         """
         # pylint: disable=super-init-not-called
@@ -10782,7 +10782,7 @@ class DestinationConfigOneOfIBMCloudObjectStorageDestinationConfig(DestinationCo
 
     :attr str bucket_name: Bucket Name for Cloud Object Storage.
     :attr str instance_id: Instance Id of Cloud Object Storage.
-    :attr str endpoint: End Point of Cloud Object Storage.
+    :attr str endpoint: Endpoint of Cloud Object Storage.
     """
 
     def __init__(
@@ -10796,7 +10796,7 @@ class DestinationConfigOneOfIBMCloudObjectStorageDestinationConfig(DestinationCo
 
         :param str bucket_name: Bucket Name for Cloud Object Storage.
         :param str instance_id: Instance Id of Cloud Object Storage.
-        :param str endpoint: End Point of Cloud Object Storage.
+        :param str endpoint: Endpoint of Cloud Object Storage.
         """
         # pylint: disable=super-init-not-called
         self.bucket_name = bucket_name
@@ -11049,22 +11049,24 @@ class DestinationConfigOneOfPagerDutyDestinationConfig(DestinationConfigOneOf):
     """
     Payload describing a PagerDuty destination configuration.
 
-    :attr str api_key: API Key for the PagerDuty account.
+    :attr str api_key: (optional) Deprecated: API Key for the PagerDuty account.
     :attr str routing_key: Routing Key (Integration Key) for the team in PagerDuty
           account.
     """
 
     def __init__(
         self,
-        api_key: str,
         routing_key: str,
+        *,
+        api_key: str = None,
     ) -> None:
         """
         Initialize a DestinationConfigOneOfPagerDutyDestinationConfig object.
 
-        :param str api_key: API Key for the PagerDuty account.
         :param str routing_key: Routing Key (Integration Key) for the team in
                PagerDuty account.
+        :param str api_key: (optional) Deprecated: API Key for the PagerDuty
+               account.
         """
         # pylint: disable=super-init-not-called
         self.api_key = api_key
@@ -11076,10 +11078,6 @@ class DestinationConfigOneOfPagerDutyDestinationConfig(DestinationConfigOneOf):
         args = {}
         if 'api_key' in _dict:
             args['api_key'] = _dict.get('api_key')
-        else:
-            raise ValueError(
-                'Required property \'api_key\' not present in DestinationConfigOneOfPagerDutyDestinationConfig JSON'
-            )
         if 'routing_key' in _dict:
             args['routing_key'] = _dict.get('routing_key')
         else:
@@ -12185,8 +12183,7 @@ class SubscriptionAttributesEventStreamsAttributesResponse(SubscriptionAttribute
     """
     The attributes for a Event Streams response.
 
-    :attr str template_id_notification: (optional) ID of Base64 converted JSON
-          Pagerduty Blocks w/o Handlebars.
+    :attr str template_id_notification: (optional) Event Streams template id.
     """
 
     # The set of defined properties for the class
@@ -12201,8 +12198,7 @@ class SubscriptionAttributesEventStreamsAttributesResponse(SubscriptionAttribute
         """
         Initialize a SubscriptionAttributesEventStreamsAttributesResponse object.
 
-        :param str template_id_notification: (optional) ID of Base64 converted JSON
-               Pagerduty Blocks w/o Handlebars.
+        :param str template_id_notification: (optional) Event Streams template id.
         :param **kwargs: (optional) Any additional properties.
         """
         # pylint: disable=super-init-not-called
@@ -13240,8 +13236,7 @@ class SubscriptionCreateAttributesEventstreamsAttributes(SubscriptionCreateAttri
     """
     The attributes for a Event Streams subscription.
 
-    :attr str template_id_notification: (optional) ID of Base64 converted JSON Slack
-          Blocks w/o Handlebars.
+    :attr str template_id_notification: (optional) Event Streams template id.
     """
 
     def __init__(
@@ -13252,8 +13247,7 @@ class SubscriptionCreateAttributesEventstreamsAttributes(SubscriptionCreateAttri
         """
         Initialize a SubscriptionCreateAttributesEventstreamsAttributes object.
 
-        :param str template_id_notification: (optional) ID of Base64 converted JSON
-               Slack Blocks w/o Handlebars.
+        :param str template_id_notification: (optional) Event Streams template id.
         """
         # pylint: disable=super-init-not-called
         self.template_id_notification = template_id_notification
@@ -14157,8 +14151,7 @@ class SubscriptionUpdateAttributesEventstreamsAttributes(SubscriptionUpdateAttri
     """
     The attributes for a Event Streams subscription.
 
-    :attr str template_id_notification: (optional) ID of Base64 converted JSON Slack
-          Blocks w/o Handlebars.
+    :attr str template_id_notification: (optional) Event Streams template id.
     """
 
     def __init__(
@@ -14169,8 +14162,7 @@ class SubscriptionUpdateAttributesEventstreamsAttributes(SubscriptionUpdateAttri
         """
         Initialize a SubscriptionUpdateAttributesEventstreamsAttributes object.
 
-        :param str template_id_notification: (optional) ID of Base64 converted JSON
-               Slack Blocks w/o Handlebars.
+        :param str template_id_notification: (optional) Event Streams template id.
         """
         # pylint: disable=super-init-not-called
         self.template_id_notification = template_id_notification

--- a/test/integration/test_event_notifications_v1.py
+++ b/test/integration/test_event_notifications_v1.py
@@ -3804,7 +3804,14 @@ class TestEventNotificationsV1:
 
     @needscredentials
     def test_delete_template(self):
-        for id in [template_invitation_id, template_notification_id, slack_template_id, webhook_template_id, pagerduty_template_id, event_streams_template_id]:
+        for id in [
+            template_invitation_id,
+            template_notification_id,
+            slack_template_id,
+            webhook_template_id,
+            pagerduty_template_id,
+            event_streams_template_id,
+        ]:
             delete_template_response = self.event_notifications_service.delete_template(instance_id, id)
         print(
             "\ndelete_template() response status code: ",


### PR DESCRIPTION
## PR summary
making api_key as deprecated for pagerduty destination

**Fixes:** 
https://github.ibm.com/Notification-Hub/planning/issues/17816

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
pagerduty destination configuration requires property api_key

## What is the new behavior?  
 api_key is depracated for pagerduty destination. only requires routing_key

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->