### PR TITLE
fix: adding the smtp config id for metrics api

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,10 @@ SDK Methods to consume
   - [Delete SMTP Configuration](#delete-smtp-user)
   - [Verify SMTP](#verify-smtp)
 - [Metrics](#Metrics)
-  - [Get Metrics](#get-metrics)
-  - [Get Bounce Metrics](#get-bounce-metrics)
+  - [Get Metrics With Destination Type](#get-metrics)
+  - [Get Metrics With SMTP Config ID](#get-metrics)
+  - [Get Bounce Metrics With Destination Type](#get-bounce-metrics)
+  - [Get Bounce Metrics With SMTP Config ID](#get-bounce-metrics)
 - [Send Notifications](#send-notifications)
 
 ## Source
@@ -1210,7 +1212,7 @@ supported verification types are dkim,spf and en_authorization.
 
 ## Metrics
 
-### Get Metrics
+### Get Metrics With Destination Type
 
 ```py
 
@@ -1231,7 +1233,27 @@ metric_response = get_metrics_response.get_result()
 
 ```
 
-### Get Bounce Metrics
+### Get Metrics With SMTP Config ID
+
+```py
+
+get_metrics_response = self.event_notifications_service.get_metrics(
+    instance_id=<instance-id>,
+    smtp_config_id=<smtp-config-id>,
+    gte=<gte-timestamp>,
+    lte=<lte-timestamp>,
+    subscription_id=subscription_id6,
+    source_id=source_id,
+    email_to=<email-to>,
+    notification_id=<notification-id>,
+    subject=<subject>
+)
+
+metric_response = get_metrics_response.get_result()
+
+```
+
+### Get Bounce Metrics With Destination Type
 
 ```py
 
@@ -1241,6 +1263,26 @@ get_bounce_metrics_response = self.event_notifications_service.get_bounce_metric
     gte=<gte-timestamp>,
     lte=<lte-timestamp>,
     destination_id=<destination-id>,
+    subscription_id=subscription_id6,
+    source_id=source_id,
+    email_to=<email-to>,
+    notification_id=<notification-id>,
+    subject=<subject>
+)
+
+bounce_metrics_response = get_bounce_metrics_response.get_result()
+
+```
+
+### Get Bounce Metrics With SMTP Config ID
+
+```py
+
+get_bounce_metrics_response = self.event_notifications_service.get_bounce_metrics(
+    instance_id=<instance-id>,
+    smtp_config_id=<smtp-config-id>,
+    gte=<gte-timestamp>,
+    lte=<lte-timestamp>,
     subscription_id=subscription_id6,
     source_id=source_id,
     email_to=<email-to>,

--- a/examples/test_event_notifications_v1_examples.py
+++ b/examples/test_event_notifications_v1_examples.py
@@ -2680,21 +2680,21 @@ class TestEventNotificationsV1Examples:
             pytest.fail(str(e))
 
     @needscredentials
-    def test_get_metrics(self):
+    def test_get_metrics_with_destination_type(self):
         try:
             print("\nget_metrics() result:")
             # begin-metrics
             destination_type = "smtp_custom"
-            gte = "2024-08-01T17:18:43Z"
-            lte = "2024-08-02T11:55:22Z"
+            gte = "2026-06-01T17:18:43Z"
+            lte = "2026-06-02T11:55:22Z"
             email_to = "testuser@in.ibm.com"
             subject = "The Metric Test"
 
             get_metrics_response = self.event_notifications_service.get_metrics(
                 instance_id,
-                destination_type,
                 gte,
                 lte,
+                destination_type=destination_type,
                 destination_id=destination_id16,
                 subscription_id=subscription_id6,
                 source_id=source_id,
@@ -2711,22 +2711,80 @@ class TestEventNotificationsV1Examples:
             pytest.fail(str(e))
 
     @needscredentials
-    def test_get_bounce_metrics(self):
+    def test_get_metrics_with_smtp_config_id(self):
+        try:
+            print("\nget_metrics() result:")
+            # begin-metrics
+            gte = "2026-06-01T17:18:43Z"
+            lte = "2026-06-02T11:55:22Z"
+            email_to = "testuser@in.ibm.com"
+            subject = "The Metric Test"
+
+            get_metrics_response = self.event_notifications_service.get_metrics(
+                instance_id,
+                gte,
+                lte,
+                smtp_config_id=smtp_config_id,
+                subscription_id=subscription_id6,
+                source_id=source_id,
+                email_to=email_to,
+                notification_id=notificationID,
+                subject=subject,
+            )
+
+            metric_response = get_metrics_response.get_result()
+            print(json.dumps(metric_response, indent=2))
+            # end-metrics
+
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_get_bounce_metrics_with_destination_type(self):
         try:
             print("\nget_bounce_metrics() result:")
             # begin-bounce-metrics
             destination_type = "smtp_custom"
-            gte = "2025-12-08T17:18:43Z"
-            lte = "2025-12-09T17:18:43Z"
+            gte = "2026-06-08T17:18:43Z"
+            lte = "2026-06-09T17:18:43Z"
             email_to = "testuser@in.ibm.com"
             subject = "The Metric Test"
 
             get_bounce_metrics_response = self.event_notifications_service.get_bounce_metrics(
                 instance_id,
-                destination_type,
                 gte,
                 lte,
+                destination_type=destination_type,
                 destination_id=destination_id16,
+                subscription_id=subscription_id6,
+                source_id=source_id,
+                email_to=email_to,
+                notification_id=notificationID,
+                subject=subject,
+            )
+
+            bounce_metric_response = get_bounce_metrics_response.get_result()
+            print(json.dumps(bounce_metric_response, indent=2))
+            # end-bounce-metrics
+
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_get_bounce_metrics_with_smtp_config_id(self):
+        try:
+            print("\nget_bounce_metrics() result:")
+            # begin-bounce-metrics
+            gte = "2026-06-08T17:18:43Z"
+            lte = "2026-06-09T17:18:43Z"
+            email_to = "testuser@in.ibm.com"
+            subject = "The Metric Test"
+
+            get_bounce_metrics_response = self.event_notifications_service.get_bounce_metrics(
+                instance_id,
+                gte,
+                lte,
+                smtp_config_id=smtp_config_id,
                 subscription_id=subscription_id6,
                 source_id=source_id,
                 email_to=email_to,

--- a/ibm_eventnotifications/event_notifications_v1.py
+++ b/ibm_eventnotifications/event_notifications_v1.py
@@ -80,10 +80,11 @@ class EventNotificationsV1(BaseService):
     def get_metrics(
         self,
         instance_id: str,
-        destination_type: str,
         gte: str,
         lte: str,
         *,
+        smtp_config_id: str = None,
+        destination_type: str = None,
         destination_id: str = None,
         subscription_id: str = None,
         source_id: str = None,
@@ -99,10 +100,13 @@ class EventNotificationsV1(BaseService):
 
         :param str instance_id: Unique identifier for IBM Cloud Event Notifications
                instance.
-        :param str destination_type: Destination type. Allowed values are
-               [smtp_custom].
         :param str gte: GTE (greater than equal), start timestamp in UTC.
         :param str lte: LTE (less than equal), end timestamp in UTC.
+        :param str smtp_config_id: (optional) SMTP configuration ID. Required when
+               querying metrics for SMTP interface destinations.
+        :param str destination_type: (optional) Destination type for which metrics
+               are requested. Supported value: smtp_custom. Required when querying metrics
+               for custom email destinations.
         :param str destination_id: (optional) Unique identifier for Destination.
         :param str subscription_id: (optional) Unique identifier for Subscription.
         :param str source_id: (optional) Unique identifier for Source.
@@ -116,8 +120,6 @@ class EventNotificationsV1(BaseService):
 
         if not instance_id:
             raise ValueError('instance_id must be provided')
-        if not destination_type:
-            raise ValueError('destination_type must be provided')
         if not gte:
             raise ValueError('gte must be provided')
         if not lte:
@@ -131,9 +133,10 @@ class EventNotificationsV1(BaseService):
         headers.update(sdk_headers)
 
         params = {
-            'destination_type': destination_type,
             'gte': gte,
             'lte': lte,
+            'smtp_config_id': smtp_config_id,
+            'destination_type': destination_type,
             'destination_id': destination_id,
             'subscription_id': subscription_id,
             'source_id': source_id,
@@ -164,10 +167,11 @@ class EventNotificationsV1(BaseService):
     def get_bounce_metrics(
         self,
         instance_id: str,
-        destination_type: str,
         gte: str,
         lte: str,
         *,
+        smtp_config_id: str = None,
+        destination_type: str = None,
         destination_id: str = None,
         subscription_id: str = None,
         source_id: str = None,
@@ -185,10 +189,13 @@ class EventNotificationsV1(BaseService):
 
         :param str instance_id: Unique identifier for IBM Cloud Event Notifications
                instance.
-        :param str destination_type: Destination type. Allowed values are
-               [smtp_custom].
         :param str gte: GTE (greater than equal), start timestamp in UTC.
         :param str lte: LTE (less than equal), end timestamp in UTC.
+        :param str smtp_config_id: (optional) SMTP configuration ID. Required when
+               querying metrics for SMTP interface destinations.
+        :param str destination_type: (optional) Destination type for which metrics
+               are requested. Supported value: smtp_custom. Required when querying metrics
+               for custom email destinations.
         :param str destination_id: (optional) Unique identifier for Destination.
         :param str subscription_id: (optional) Unique identifier for Subscription.
         :param str source_id: (optional) Unique identifier for Source.
@@ -204,8 +211,6 @@ class EventNotificationsV1(BaseService):
 
         if not instance_id:
             raise ValueError('instance_id must be provided')
-        if not destination_type:
-            raise ValueError('destination_type must be provided')
         if not gte:
             raise ValueError('gte must be provided')
         if not lte:
@@ -219,9 +224,10 @@ class EventNotificationsV1(BaseService):
         headers.update(sdk_headers)
 
         params = {
-            'destination_type': destination_type,
             'gte': gte,
             'lte': lte,
+            'smtp_config_id': smtp_config_id,
+            'destination_type': destination_type,
             'destination_id': destination_id,
             'subscription_id': subscription_id,
             'source_id': source_id,
@@ -3479,7 +3485,8 @@ class GetMetricsEnums:
 
     class DestinationType(str, Enum):
         """
-        Destination type. Allowed values are [smtp_custom].
+        Destination type for which metrics are requested. Supported value: smtp_custom.
+        Required when querying metrics for custom email destinations.
         """
 
         SMTP_CUSTOM = 'smtp_custom'
@@ -3492,7 +3499,8 @@ class GetBounceMetricsEnums:
 
     class DestinationType(str, Enum):
         """
-        Destination type. Allowed values are [smtp_custom].
+        Destination type for which metrics are requested. Supported value: smtp_custom.
+        Required when querying metrics for custom email destinations.
         """
 
         SMTP_CUSTOM = 'smtp_custom'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 # test dependencies
 coverage>=7.3.2
 pylint>=3.0.0,<4.0.0
-pytest>=7.4.2,<8.0.0
+pytest>=9.1.1,<10.0.0
 pytest-cov>=4.1.0,<5.0.0
 responses>=0.23.3,<1.0.0
 black>=26.3.1

--- a/test/integration/test_event_notifications_v1.py
+++ b/test/integration/test_event_notifications_v1.py
@@ -3954,19 +3954,19 @@ class TestEventNotificationsV1:
         #
 
     @needscredentials
-    def test_get_metrics(self):
+    def test_get_metrics_with_destination_type(self):
 
         destination_type = "smtp_custom"
-        gte = "2025-12-08T17:18:43Z"
-        lte = "2025-12-09T17:18:43Z"
+        gte = "2026-06-01T17:18:43Z"
+        lte = "2026-06-08T17:18:43Z"
         email_to = "testuser@in.ibm.com"
         subject = "The Metric Test"
 
         get_metrics_response = self.event_notifications_service.get_metrics(
             instance_id,
-            destination_type,
             gte,
             lte,
+            destination_type=destination_type,
             destination_id=destination_id16,
             subscription_id=subscription_id16,
             source_id=source_id,
@@ -3980,18 +3980,66 @@ class TestEventNotificationsV1:
         assert metric_response is not None
 
     @needscredentials
-    def test_get_bounce_metrics(self):
-        destination_type = "smtp_custom"
-        gte = "2025-12-08T17:18:43Z"
-        lte = "2025-12-09T17:18:43Z"
+    def test_get_metrics_with_smtp_config_id(self):
+        smtp_config_id = "a986b071-72b9-4968-8bb2-5a8c36eb86e4"
+        gte = "2026-06-01T17:18:43Z"
+        lte = "2026-06-03T17:18:43Z"
+        email_to = "testuser@in.ibm.com"
+        subject = "The Metric Test"
+
+        get_metrics_response = self.event_notifications_service.get_metrics(
+            instance_id,
+            gte,
+            lte,
+            smtp_config_id=smtp_config_id,
+            subscription_id=subscription_id16,
+            source_id=source_id,
+            email_to=email_to,
+            notification_id=notificationID,
+            subject=subject,
+        )
+
+        assert get_metrics_response.get_status_code() == 200
+        metric_response = get_metrics_response.get_result()
+        assert metric_response is not None
+
+    @needscredentials
+    def test_get_bounce_metrics_with_smtp_config_id(self):
+        smtp_config_id = "a986b071-72b9-4968-8bb2-5a8c36eb86e4"
+        gte = "2026-06-08T17:18:43Z"
+        lte = "2026-06-09T17:18:43Z"
         email_to = "testuser@in.ibm.com"
         subject = "The Metric Test"
 
         get_bounce_metrics_response = self.event_notifications_service.get_bounce_metrics(
             instance_id,
-            destination_type,
             gte,
             lte,
+            smtp_config_id=smtp_config_id,
+            subscription_id=subscription_id16,
+            source_id=source_id,
+            email_to=email_to,
+            notification_id=notificationID,
+            subject=subject,
+        )
+
+        assert get_bounce_metrics_response.get_status_code() == 200
+        bounce_metric_response = get_bounce_metrics_response.get_result()
+        assert bounce_metric_response is not None
+
+    @needscredentials
+    def test_get_bounce_metrics_with_destination_type(self):
+        destination_type = "smtp_custom"
+        gte = "2026-06-08T17:18:43Z"
+        lte = "2026-06-09T17:18:43Z"
+        email_to = "testuser@in.ibm.com"
+        subject = "The Metric Test"
+
+        get_bounce_metrics_response = self.event_notifications_service.get_bounce_metrics(
+            instance_id,
+            gte,
+            lte,
+            destination_type=destination_type,
             destination_id=destination_id16,
             subscription_id=subscription_id16,
             source_id=source_id,

--- a/test/unit/test_event_notifications_v1.py
+++ b/test/unit/test_event_notifications_v1.py
@@ -121,9 +121,10 @@ class TestGetMetrics:
 
         # Set up parameter values
         instance_id = 'testString'
-        destination_type = 'smtp_custom'
         gte = 'testString'
         lte = 'testString'
+        smtp_config_id = 'testString'
+        destination_type = 'smtp_custom'
         destination_id = 'testString'
         subscription_id = 'testString'
         source_id = 'testString'
@@ -134,9 +135,10 @@ class TestGetMetrics:
         # Invoke method
         response = _service.get_metrics(
             instance_id,
-            destination_type,
             gte,
             lte,
+            smtp_config_id=smtp_config_id,
+            destination_type=destination_type,
             destination_id=destination_id,
             subscription_id=subscription_id,
             source_id=source_id,
@@ -152,9 +154,10 @@ class TestGetMetrics:
         # Validate query params
         query_string = responses.calls[0].request.url.split('?', 1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
-        assert 'destination_type={}'.format(destination_type) in query_string
         assert 'gte={}'.format(gte) in query_string
         assert 'lte={}'.format(lte) in query_string
+        assert 'smtp_config_id={}'.format(smtp_config_id) in query_string
+        assert 'destination_type={}'.format(destination_type) in query_string
         assert 'destination_id={}'.format(destination_id) in query_string
         assert 'subscription_id={}'.format(subscription_id) in query_string
         assert 'source_id={}'.format(source_id) in query_string
@@ -189,14 +192,12 @@ class TestGetMetrics:
 
         # Set up parameter values
         instance_id = 'testString'
-        destination_type = 'smtp_custom'
         gte = 'testString'
         lte = 'testString'
 
         # Invoke method
         response = _service.get_metrics(
             instance_id,
-            destination_type,
             gte,
             lte,
             headers={},
@@ -208,7 +209,6 @@ class TestGetMetrics:
         # Validate query params
         query_string = responses.calls[0].request.url.split('?', 1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
-        assert 'destination_type={}'.format(destination_type) in query_string
         assert 'gte={}'.format(gte) in query_string
         assert 'lte={}'.format(lte) in query_string
 
@@ -239,14 +239,12 @@ class TestGetMetrics:
 
         # Set up parameter values
         instance_id = 'testString'
-        destination_type = 'smtp_custom'
         gte = 'testString'
         lte = 'testString'
 
         # Pass in all but one required param and check for a ValueError
         req_param_dict = {
             "instance_id": instance_id,
-            "destination_type": destination_type,
             "gte": gte,
             "lte": lte,
         }
@@ -288,9 +286,10 @@ class TestGetBounceMetrics:
 
         # Set up parameter values
         instance_id = 'testString'
-        destination_type = 'smtp_custom'
         gte = 'testString'
         lte = 'testString'
+        smtp_config_id = 'testString'
+        destination_type = 'smtp_custom'
         destination_id = 'testString'
         subscription_id = 'testString'
         source_id = 'testString'
@@ -303,9 +302,10 @@ class TestGetBounceMetrics:
         # Invoke method
         response = _service.get_bounce_metrics(
             instance_id,
-            destination_type,
             gte,
             lte,
+            smtp_config_id=smtp_config_id,
+            destination_type=destination_type,
             destination_id=destination_id,
             subscription_id=subscription_id,
             source_id=source_id,
@@ -323,9 +323,10 @@ class TestGetBounceMetrics:
         # Validate query params
         query_string = responses.calls[0].request.url.split('?', 1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
-        assert 'destination_type={}'.format(destination_type) in query_string
         assert 'gte={}'.format(gte) in query_string
         assert 'lte={}'.format(lte) in query_string
+        assert 'smtp_config_id={}'.format(smtp_config_id) in query_string
+        assert 'destination_type={}'.format(destination_type) in query_string
         assert 'destination_id={}'.format(destination_id) in query_string
         assert 'subscription_id={}'.format(subscription_id) in query_string
         assert 'source_id={}'.format(source_id) in query_string
@@ -362,14 +363,12 @@ class TestGetBounceMetrics:
 
         # Set up parameter values
         instance_id = 'testString'
-        destination_type = 'smtp_custom'
         gte = 'testString'
         lte = 'testString'
 
         # Invoke method
         response = _service.get_bounce_metrics(
             instance_id,
-            destination_type,
             gte,
             lte,
             headers={},
@@ -381,7 +380,6 @@ class TestGetBounceMetrics:
         # Validate query params
         query_string = responses.calls[0].request.url.split('?', 1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
-        assert 'destination_type={}'.format(destination_type) in query_string
         assert 'gte={}'.format(gte) in query_string
         assert 'lte={}'.format(lte) in query_string
 
@@ -412,14 +410,12 @@ class TestGetBounceMetrics:
 
         # Set up parameter values
         instance_id = 'testString'
-        destination_type = 'smtp_custom'
         gte = 'testString'
         lte = 'testString'
 
         # Pass in all but one required param and check for a ValueError
         req_param_dict = {
             "instance_id": instance_id,
-            "destination_type": destination_type,
             "gte": gte,
             "lte": lte,
         }


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->

**Fixes:** https://github.ibm.com/Notification-Hub/planning/issues/19982

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
For the GET /metrics API current documentation states that destination_type is a mandatory parameter for retrieving metrics. However, this is not accurate, as metrics can be retrieved without always providing destination_type.
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?  
For the GET /metrics API, users can provide either destination_type or smtp_config_id to retrieve metrics. Supplying both parameters is not required.
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->